### PR TITLE
Display audio duration instead of file size in AudioClipCard

### DIFF
--- a/src/components/AudioClipCard.tsx
+++ b/src/components/AudioClipCard.tsx
@@ -4,7 +4,7 @@ import { Ionicons } from '@expo/vector-icons'
 
 import { theme } from '../utils/theme'
 import { FileContextMenuModal } from './FileContextMenuModal'
-import { formatDateSmart, formatFileSize } from '../utils/formatUtils'
+import { formatDateSmart, formatAudioDuration } from '../utils/formatUtils'
 
 export type AudioClipData = {
   id: string
@@ -81,8 +81,7 @@ export const AudioClipCard = React.memo(function AudioClipCard({
             {clip.name}
           </Text>
           <Text style={styles.details}>
-            {formatDateSmart(clip.createdAt)} • {formatFileSize(clip.size)}
-            {clip.duration && ` • ${clip.duration}`}
+            {formatDateSmart(clip.createdAt)} • {formatAudioDuration(clip.duration)}
           </Text>
         </View>
 

--- a/src/utils/__tests__/formatUtils.test.ts
+++ b/src/utils/__tests__/formatUtils.test.ts
@@ -5,6 +5,7 @@
 import {
   formatDuration,
   formatDurationFromSeconds,
+  formatAudioDuration,
   formatFileSize,
   formatDate,
   formatDateSmart,
@@ -39,6 +40,36 @@ describe('formatUtils', () => {
     it('should handle large durations', () => {
       expect(formatDurationFromSeconds(7200)).toBe('120:00') // 2 hours
       expect(formatDurationFromSeconds(3599)).toBe('59:59')
+    })
+  })
+
+  describe('formatAudioDuration', () => {
+    it('should return fallback for undefined/null/NaN values', () => {
+      expect(formatAudioDuration(undefined)).toBe('--:--')
+      expect(formatAudioDuration(null as any)).toBe('--:--')
+      expect(formatAudioDuration(NaN)).toBe('--:--')
+    })
+
+    it('should format short durations as MM:SS', () => {
+      expect(formatAudioDuration(0)).toBe('00:00')
+      expect(formatAudioDuration(1)).toBe('00:01')
+      expect(formatAudioDuration(60)).toBe('01:00')
+      expect(formatAudioDuration(90)).toBe('01:30')
+      expect(formatAudioDuration(225)).toBe('03:45')
+      expect(formatAudioDuration(3599)).toBe('59:59') // Just under 1 hour
+    })
+
+    it('should format long durations as HH:MM:SS', () => {
+      expect(formatAudioDuration(3600)).toBe('1:00:00') // Exactly 1 hour
+      expect(formatAudioDuration(3661)).toBe('1:01:01') // 1 hour, 1 minute, 1 second
+      expect(formatAudioDuration(5025)).toBe('1:23:45') // 1 hour, 23 minutes, 45 seconds
+      expect(formatAudioDuration(7200)).toBe('2:00:00') // 2 hours
+      expect(formatAudioDuration(36000)).toBe('10:00:00') // 10 hours
+    })
+
+    it('should handle fractional seconds by flooring', () => {
+      expect(formatAudioDuration(90.7)).toBe('01:30')
+      expect(formatAudioDuration(3661.9)).toBe('1:01:01')
     })
   })
 

--- a/src/utils/formatUtils.ts
+++ b/src/utils/formatUtils.ts
@@ -72,6 +72,30 @@ export function formatDateSmart(date: Date): string {
 }
 
 /**
+ * Format audio duration with smart MM:SS or HH:MM:SS formatting
+ * @param seconds Duration in seconds (optional)
+ * @returns Formatted duration string or "--:--" if undefined
+ */
+export function formatAudioDuration(seconds?: number): string {
+  if (seconds === undefined || seconds === null || isNaN(seconds)) {
+    return '--:--'
+  }
+
+  const totalSeconds = Math.floor(seconds)
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const remainingSeconds = totalSeconds % 60
+
+  if (hours > 0) {
+    // Format as HH:MM:SS for durations 1 hour or longer
+    return `${hours}:${minutes.toString().padStart(2, '0')}:${remainingSeconds.toString().padStart(2, '0')}`
+  } else {
+    // Format as MM:SS for durations under 1 hour
+    return `${minutes.toString().padStart(2, '0')}:${remainingSeconds.toString().padStart(2, '0')}`
+  }
+}
+
+/**
  * Generate a default recording name with gap-filling logic
  * Scans existing files to find the lowest available number in the "Recording X" sequence
  *


### PR DESCRIPTION
## Summary

Replaces file size display with audio duration in the AudioClipCard component details line.

## Changes

### New Features
- Added `formatAudioDuration()` function with smart MM:SS/HH:MM:SS formatting
- Handles undefined duration with "--:--" fallback
- Formats durations under 1 hour as MM:SS (e.g., "03:45")
- Formats durations 1 hour or longer as HH:MM:SS (e.g., "1:23:45")

### Updated Components
- **AudioClipCard**: Replaced `formatFileSize(clip.size)` with `formatAudioDuration(clip.duration)`
- Maintains existing date • duration format pattern
- Removed redundant duration display logic

### Testing
- Added comprehensive tests for `formatAudioDuration()` function
- All tests pass (4/4 new tests)
- TypeScript compilation passes
- Linting passes with no new issues

## Files Changed
- `src/utils/formatUtils.ts` - Added new duration formatting function
- `src/components/AudioClipCard.tsx` - Updated to use duration instead of file size
- `src/utils/__tests__/formatUtils.test.ts` - Added tests for new function

## Testing
```bash
npm run type-check  # ✅ Passes
npm test -- --testNamePattern="formatAudioDuration"  # ✅ 4/4 tests pass
npm run lint  # ✅ No new issues
```

## Before/After

**Before:** `Today • 2.1 MB`
**After:** `Today • 03:45` or `Today • 1:23:45` (for longer clips)

Closes: Display audio duration instead of file size requirement

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author